### PR TITLE
Created new release from previous 2 commits 4.3.2

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -36,7 +36,7 @@ Deze addon kan in een keer je hele videocollectie verwijderen! Zorg dat je preci
         <website/>
         <email/>
         <news>
-[B][I]Version 4.3.1[/I][/B]
+[B][I]Version 4.3.2[/I][/B]
 - [FIX] Fixing some exclusions that prevented cleaning.
 - [FIX] Fix metadata
 [B][I]Version 4.3.1[/I][/B]

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.service.janitor" name="Janitor" version="4.3.1" provider-name="Anthirian, drewzh">
+<addon id="script.service.janitor" name="Janitor" version="4.3.2" provider-name="Anthirian, drewzh">
     <requires>
         <import addon="xbmc.python" version="2.25.0" />
         <import addon="xbmc.json" version="7.0.0" />
@@ -36,6 +36,9 @@ Deze addon kan in een keer je hele videocollectie verwijderen! Zorg dat je preci
         <website/>
         <email/>
         <news>
+[B][I]Version 4.3.1[/I][/B]
+- [FIX] Fixing some exclusions that prevented cleaning.
+- [FIX] Fix metadata
 [B][I]Version 4.3.1[/I][/B]
 - [FIX] Better unicode support
 - [FIX] Obey all exclusions


### PR DESCRIPTION
I had issues for months now with version 4.3.1 getting hung up on some characters it couldn't decode. Then I pulled the latest two commits, updated the version to 4.3.2 and replaced the contents of "/var/lib/kodi/.kodi/addons/script.service.janitor/" with those of the repo. Did a restart and it immediately cleaned over 300 items. Those were seriously clogging up my disk. I don't know how to publish to the official kodi repos but you should definitely get this out to the public because I am sure it will help a lot of people.
In the meantime you can download the latest version from here: https://github.com/Rusk85/script.service.janitor/releases/latest